### PR TITLE
Entity escape redirect URL

### DIFF
--- a/newweb/response.py
+++ b/newweb/response.py
@@ -3,6 +3,7 @@
 
 # Standard modules
 import httplib
+from xml.sax import saxutils
 
 
 class Response(object):
@@ -79,13 +80,13 @@ class Response(object):
 
 class Redirect(Response):
   """A response tailored to do redirects."""
-  REDIRECT_PAGE = ('<!DOCTYPE html><html><head><title>Page moved</title></head>'
-                   '<body>Page moved, please follow <a href="%s">this link</a>'
-                   '</body></html>')
+  REDIRECT_PAGE = (
+      '<!DOCTYPE html><html><head><title>Page moved</title></head><body>'
+      'Page moved, please follow <a href=%s>this link</a></body></html>')
 
   def __init__(self, location, httpcode=307):
     super(Redirect, self).__init__(
-        content=self.REDIRECT_PAGE % location,
+        content=self.REDIRECT_PAGE % saxutils.quoteattr(location),
         content_type='text/html',
         httpcode=httpcode,
         headers={'Location': location})

--- a/newweb/templateparser.py
+++ b/newweb/templateparser.py
@@ -14,6 +14,7 @@ Error classes:
 import os
 import re
 import urllib
+from xml.sax import saxutils
 
 
 class Error(Exception):
@@ -865,19 +866,15 @@ def HtmlEscape(text):
   The relevant defined set consists of the following characters: &'"<>
 
   Takes:
-    @ html: str
-      The html string with html character entities.
+    @ text: str
+      Raw test that needs entity-escaping
 
   Returns:
-    str: the input, after turning entites back into raw characters.
+    str: the input, after converting necessary characters to entity-refs.
   """
   if not isinstance(text, basestring):
-    text = unicode(text)
-  html = text.replace('&', '&amp;')
-  html = html.replace('"', '&quot;')
-  html = html.replace("'", '&#39;')  # &apos; is valid, but poorly supported.
-  html = html.replace('>', '&gt;')
-  return html.replace('<', '&lt;')
+    text = unicode(text)  # Get string representation of non-string object
+  return saxutils.escape(text, {'"': '&quot;', "'": '&#39;'})
 
 
 def UrlQuote(text):

--- a/newweb/test_response.py
+++ b/newweb/test_response.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+"""Tests for the response module."""
+
+# Standard modules
+import unittest
+
+# Unittest target
+from . import response
+
+
+class RedirectTest(unittest.TestCase):
+  """Tests for redirect responses."""
+
+  def testRedirect(self):
+    """Redirects generate a minimal body with a hyperlink for dumb clients."""
+    redirect = response.Redirect('https://google.com')
+    self.assertIn('https://google.com', redirect.text)
+
+  def testRedirectEscapedBodyLink(self):
+    """Redirect links are correctly entity-escaped to prevent XSS and such."""
+    redirect = response.Redirect('<script>alert("hi")</script>')
+    self.assertNotIn('<script>', redirect.text)
+    self.assertIn('&lt;script&gt;', redirect.text)
+
+
+if __name__ == '__main__':
+  unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/newweb/test_templateparser.py
+++ b/newweb/test_templateparser.py
@@ -282,6 +282,13 @@ class TemplateTagFunctions(unittest.TestCase):
     self.assertEqual(self.parse(default, none='"nothing"'), expected)
     self.assertEqual(self.parse(escaped, none='"nothing"'), expected)
 
+  def testAllHtmlEscapes(self):
+    """[TagFunctions] The default function escapes all verboten characters."""
+    template = '[text]'
+    template_input = '"Quotes" \'n <brackets> & such'
+    expected = '&quot;Quotes&quot; &#39;n &lt;brackets&gt; &amp; such'
+    self.assertEqual(self.parse(template, text=template_input), expected)
+
   def testNoDefaultForSafeString(self):
     """[TagFunctions] The default function does not act upon SafeString parts"""
     first_template = 'Hello doctor [name]'


### PR DESCRIPTION
* Updates `Redirect` class body creation with entity-escaping suitable for (HT|SG|X)ML, this resolves #12;
* Adds a minimal test suite for the `response.Redirect` class to test this fix;
* Simplifies `HtmlEscape` function in templateparser module and fixes its wrong-way-around docstring.